### PR TITLE
Fix NoSuchMethodError when using a recent version of spring-data-redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,31 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <spring-data.version>1.8.9.RELEASE</spring-data.version>
+        <jedis>2.9.0</jedis>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-redis</artifactId>
-            <version>1.0.3.RELEASE</version>
+            <version>${spring-data.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedis}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,25 +84,43 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.0.9</version>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.12</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>3.2.1.RELEASE</version>
+            <version>4.3.10.RELEASE</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.1</version>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/github/davidmarquis/redisscheduler/RedisTaskSchedulerIntegrationTest.java
+++ b/src/test/java/com/github/davidmarquis/redisscheduler/RedisTaskSchedulerIntegrationTest.java
@@ -14,6 +14,7 @@ import java.text.ParseException;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -161,7 +162,7 @@ public class RedisTaskSchedulerIntegrationTest {
         taskTriggerListener.waitUntilTriggered(tasks.length, 1000);
 
         assertThat("Triggered tasks count", taskTriggerListener.getTriggeredTasks().size(), is(tasks.length));
-        assertThat("Triggered tasks", taskTriggerListener.getTriggeredTasks(), is(asList(tasks)));
+        assertThat("Triggered tasks", taskTriggerListener.getTriggeredTasks(), hasItems(tasks));
     }
 
     private void assertOnlyTasksTriggered(String... tasks) throws InterruptedException {

--- a/src/test/java/com/github/davidmarquis/redisscheduler/RedisTaskSchedulerIntegrationTest.java
+++ b/src/test/java/com/github/davidmarquis/redisscheduler/RedisTaskSchedulerIntegrationTest.java
@@ -14,7 +14,6 @@ import java.text.ParseException;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.HOURS;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -162,7 +161,7 @@ public class RedisTaskSchedulerIntegrationTest {
         taskTriggerListener.waitUntilTriggered(tasks.length, 1000);
 
         assertThat("Triggered tasks count", taskTriggerListener.getTriggeredTasks().size(), is(tasks.length));
-        assertThat("Triggered tasks", taskTriggerListener.getTriggeredTasks(), hasItems(tasks));
+        assertThat("Triggered tasks", taskTriggerListener.getTriggeredTasks(), is(asList(tasks)));
     }
 
     private void assertOnlyTasksTriggered(String... tasks) throws InterruptedException {


### PR DESCRIPTION
Hi David,

I use your `redis-scheduler` lib with `spring-data-redis:1.8.x.RELEASE`.
Because the project has been compiled with an older version (signature `boolean remove(...)`) it leads to this error in the `PollingThread`.

* Upgrade dependencies
* Just a little change in the test case because on my machine the list contains the same task twice.