### PR TITLE
fix retry polling when Jedis Connection error happens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ redis-scheduler
 ===============
 
 Distributed Scheduler using Redis for Java applications.
+[fork redis-scheduler 3.0.0 by David Marquis](https://github.com/davidmarquis/redis-scheduler)
 
 What is this?
 -------------

--- a/RELEASENOTE..md
+++ b/RELEASENOTE..md
@@ -1,3 +1,8 @@
+# 3.0.2
+
+### features
+- update version to run with springboot 3.1
+
 # 3.0.1
 
 ### features

--- a/RELEASENOTE..md
+++ b/RELEASENOTE..md
@@ -1,0 +1,8 @@
+# 3.0.1
+
+### features
+- fix retry polling when Jedis Connection error happens
+
+# 3.0.0
+[fork redis-scheduler 3.0.0 by David Marquis](https://github.com/davidmarquis/redis-scheduler)
+

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -236,7 +236,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.davidmarquis</groupId>
+    <groupId>io.github.christianmelon</groupId>
     <artifactId>redis-scheduler</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.1</version>
     <packaging>jar</packaging>
 
     <name>redis-scheduler</name>
-    <description>Java implementation of a lightweight distributed task scheduler backed by Redis</description>
-    <url>https://github.com/davidmarquis/redis-scheduler</url>
+    <description>fork : Java implementation of a lightweight distributed task scheduler backed by Redis</description>
+    <url>https://github.com/christianmelon/redis-scheduler</url>
 
     <licenses>
         <license>
@@ -20,28 +20,28 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:davidmarquis/redis-scheduler.git</connection>
-        <developerConnection>scm:git:git@github.com:davidmarquis/redis-scheduler.git</developerConnection>
-        <url>git@github.com:davidmarquis/redis-scheduler.git</url>
+        <connection>scm:git:git@github.com:christianmelon/redis-scheduler.git</connection>
+        <developerConnection>scm:git:git@github.com:christianmelon/redis-scheduler.git</developerConnection>
+        <url>git@github.com:christianmelon/redis-scheduler.git</url>
         <tag>HEAD</tag>
     </scm>
 
     <developers>
         <developer>
-            <id>davidmarquis</id>
-            <name>David Marquis</name>
-            <email>david@radiant3.ca</email>
+            <id>christianmelon</id>
+            <name>Christian Melon</name>
+            <email>christian.melon@orange.com</email>
         </developer>
     </developers>
 
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -226,7 +226,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.christianmelon</groupId>
     <artifactId>redis-scheduler</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <packaging>jar</packaging>
 
     <name>redis-scheduler</name>
@@ -47,21 +47,21 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.2</version>
         </dependency>
         
         <!-- Lettuce driver -->
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>5.0.3.RELEASE</version>
+            <version>6.2.5.RELEASE</version>
             <scope>provided</scope>
         </dependency>
 
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.9.0</version>
+            <version>4.3.2</version>
             <scope>provided</scope>
         </dependency>
 
@@ -77,25 +77,25 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-redis</artifactId>
-            <version>1.8.11.RELEASE</version>
+            <version>3.1.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
-            <version>2.2</version>
+            <version>2.11.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>4.3.15.RELEASE</version>
+            <version>6.0.11</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>4.3.15.RELEASE</version>
+            <version>6.0.11</version>
             <scope>test</scope>
         </dependency>
 
@@ -103,9 +103,16 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.4.8</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.7</version>
+        </dependency>
+
         <dependency>
             <groupId>com.github.kstyrc</groupId>
             <artifactId>embedded-redis</artifactId>
@@ -115,7 +122,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,8 +133,15 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -146,7 +160,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -159,7 +173,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.0</version>
+                        <version>3.4.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -202,7 +216,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -211,7 +225,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>

--- a/src/main/java/com/github/davidmarquis/redisscheduler/PollingThread.java
+++ b/src/main/java/com/github/davidmarquis/redisscheduler/PollingThread.java
@@ -2,6 +2,7 @@ package com.github.davidmarquis.redisscheduler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 class PollingThread extends Thread {
 
@@ -60,9 +61,10 @@ class PollingThread extends Thread {
             }
 
             resetRetriesAttemptsCount();
-        } catch (RedisConnectException e) {
+        } catch (RedisConnectException | JedisConnectionException e) {
             incrementRetriesAttemptsCount();
             log.warn(String.format("Connection failure during scheduler polling (attempt %s/%s)", numRetriesAttempted, maxRetriesOnConnectionFailure));
+            sleep(pollingDelayMillis);
         }
     }
 

--- a/src/main/java/com/github/davidmarquis/redisscheduler/drivers/jedis/JedisDriver.java
+++ b/src/main/java/com/github/davidmarquis/redisscheduler/drivers/jedis/JedisDriver.java
@@ -79,7 +79,7 @@ public class JedisDriver implements RedisDriver {
             } finally {
                 try {
                     txn.close();
-                } catch (IOException e) {
+                } catch (Exception e) {
                     throw new RedisConnectException(e);
                 }
                 txn = null;

--- a/src/test/java/com/github/davidmarquis/redisscheduler/RedisTaskSchedulerTest.java
+++ b/src/test/java/com/github/davidmarquis/redisscheduler/RedisTaskSchedulerTest.java
@@ -5,11 +5,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
 
 import java.util.function.Function;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.atLeast;
 import static org.mockito.internal.verification.VerificationModeFactory.times;


### PR DESCRIPTION
Hello David,

I use the redis-scheluder in production.  I use Jedis. We have randomly some errors connection with redis but the retry doesnt work in my case.

Added in the catch attemptTriggerNextTask
•	JedisConnectionException 
•	a delay before the next retry

thanks